### PR TITLE
`k_aug -v` should print version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ set(libmetisname "coinmetis")
 set(libblasname "openblas")
 set(liblapackname "openblas")
 set(LDL "dl")
-set(QUADMATH "")
+ 
 
 if (${OS} MATCHES "CYGWIN")
 message(STATUS "\n\nCYGWIN DETECTED:\n Make sure LAPACK is in the PATH after
@@ -46,14 +46,12 @@ compilation")
     elseif(${OS} MATCHES "MINGW64")
     message(STATUS "\n\nMINGW64 DECTECTED (This is still experimental)")
     message(STATUS "Make sure the library names are consistent")  # !
-    set(USE_MINGW64 1)
     set(libaslname "libcoinasl.dll.a")
     set(libhslname "libcoinhsl.dll.a")
     set(libmetisname "libmetis.dll.a")
     set(libblasname "libblas.dll.a")
     set(liblapackname "liblapack.dll.a")
     set(LDL "")
-    set(QUADMATH "quadmath")
     elseif(${OS} MATCHES "Darwin")
    message(STATUS "\n\nYou are trying to compile k_aug in Mac OS X")
    message(STATUS "\n\nMake sure the libgfortran.dylib is available in a
@@ -78,7 +76,7 @@ set(k_aug_version_minor 0)
 
 set(USE_PARDISO 0)
 set(USE_MC30 0)
-set(PRINT_VERBOSE 0)
+set(PRINT_VERBOSE 1)
  
 
 configure_file("${PROJECT_SOURCE_DIR}/src/common/config_kaug.h.in"
@@ -90,23 +88,25 @@ include_directories(${PROJECT_BINARY_DIR})
 
 # coinor stuff
 # PLEASE MAKE SURE THIS ARE IN THE CORRECT DIRECTORY
-include_directories(/usr/local/include/coin-or/asl )  #: Add location of asl.h getstub.h
-find_library(COINASL NAMES asl ${libaslname} HINTS /usr/local/lib REQUIRED)  #: Add hints
-find_library(COINHSL NAMES ${libhslname} HINTS /usr/local/lib REQUIRED)  #: Add hints
-find_library(COINMETIS NAMES metis ${libmetisname} HINTS /usr/local/lib REQUIRED)  #: Add hints
-
+include_directories(/home/rparker1/Solvers/CoinIpopt/build/include/coin/ThirdParty)
+find_library(COINASL NAMES asl ${libaslname} HINTS /home/rparker1/Solvers/CoinIpopt/build/lib /usr/local/lib REQUIRED)
+find_library(COINHSL ${libhslname} HINTS /home/rparker1/Solvers/CoinIpopt/build/lib /usr/local/lib REQUIRED)
+find_library(COINMETIS NAMES metis ${libmetisname} HINTS /home/rparker1/Solvers/CoinIpopt/build/lib /usr/local/lib
+/usr/local/opt/metis/lib/ REQUIRED)
 # openblas/blas stuff
-find_library(BLAS NAMES blas ${libblasname} HINTS /usr/lib /usr/local/lib REQUIRED)  #: Add hints
-find_library(LAPACK NAMES lapack ${liblapackname} HINTS /usr/lib /usr/local/lib REQUIRED)  #: Add hints
-#: libgfortran
-find_library(GFORTRAN NAMES gfortran HINTS /usr/local/opt/gcc/lib/gcc/10 REQUIRED)  #: Sometimes on macOS /usr/local/opt/gcc/lib/gcc/10
-#: Sometimes on linux /usr/lib/gcc/x86_64-linux-gnu/X otherwise /usr/lib/gcc/arch-os/VERSION
+find_library(BLAS NAMES blas ${libblasname} HINTS /home/rparker1/Solvers/CoinIpopt/build/lib /usr/lib /usr/local/lib REQUIRED)
+find_library(LAPACK NAMES lapack ${liblapackname} HINTS /home/rparker1/Solvers/CoinIpopt/build/lib /usr/lib /usr/local/lib REQUIRED)
+find_library(GFORTRAN NAMES gfortran HINTS /usr/lib/x86_64-linux-gnu /usr/lib/gcc/x86_64-linux-gnu/7 /usr/local/opt/gcc/lib/gcc/10 REQUIRED)  #: ATTENTION MAC OS X USERS!
+ 
 
-message(STATUS "\n\n'")
+ 
 
-get_property(dirs DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)
-message(STATUS
-        "\n\n\nThe include directories must have getstub.h, arith.h, and asl.h!!!\n\n\n")
+ 
+
+get_property(dirs DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY
+INCLUDE_DIRECTORIES)
+message(STATUS "\n\n\nThe include directories must have getstub.h, arith.h,
+and asl.h!!!\n\n\n")
 foreach(dir ${dirs})
     message(STATUS "Including directory='${dir}'")
 endforeach()
@@ -126,7 +126,6 @@ set(SRC_FILES ${PROJECT_SOURCE_DIR}/src/k_aug/main_.c
         ${PROJECT_SOURCE_DIR}/src/k_aug/csr_driver.c
         ${PROJECT_SOURCE_DIR}/src/k_aug/dot_driver.c
         ${PROJECT_SOURCE_DIR}/src/k_aug/find_inequalities.c
-        ${PROJECT_SOURCE_DIR}/src/k_aug/get_grad_f.c
         ${PROJECT_SOURCE_DIR}/src/k_aug/get_jac_asl_aug.c
         ${PROJECT_SOURCE_DIR}/src/k_aug/get_hess_asl_aug.c
         ${PROJECT_SOURCE_DIR}/src/k_aug/inertia_strategy.c
@@ -146,18 +145,22 @@ add_executable(k_aug ${SRC_FILES})
 add_executable(dot_sens src/k_aug/dot_driver/dot_driver.c)
 if (USE_MC30)
     #target_link_libraries(k_aug amplsolver m dl gfortran dmumps mumps_common
-    #pthread esmumps scotch scotcherr metis pord mpiseq mc30 gfortran openblas
-    #ma57)
+#pthread esmumps scotch scotcherr metis pord mpiseq mc30 gfortran openblas
+#ma57)
     target_link_libraries(k_aug mc30 ${COINASL} ${COINHSL} ${COINMETIS}
-${LAPACK} ${BLAS} ${GFORTRAN} ${QUADMATH} m ${LDL})
+${LAPACK} ${BLAS} ${GFORTRAN} m ${LDL})
     message("LINKING MC30 ${USE_MC30}")
 else(USE_MC30)
+message(${LAPACK})
+message(${GFORTRAN})
 target_link_libraries(k_aug ${COINASL} ${COINHSL} ${COINMETIS}  ${LAPACK}
-${BLAS} ${GFORTRAN} ${QUADMATH} m ${LDL})
+${BLAS} ${GFORTRAN} m ${LDL})
 endif(USE_MC30)
  
 
-target_link_libraries(dot_sens ${COINASL} ${BLAS} ${GFORTRAN} ${QUADMATH} m ${LDL})
+ 
+
+target_link_libraries(dot_sens ${COINASL} ${BLAS} ${GFORTRAN} m ${LDL})
  
 
  

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ set(libmetisname "coinmetis")
 set(libblasname "openblas")
 set(liblapackname "openblas")
 set(LDL "dl")
- 
+set(QUADMATH "")
 
 if (${OS} MATCHES "CYGWIN")
 message(STATUS "\n\nCYGWIN DETECTED:\n Make sure LAPACK is in the PATH after
@@ -46,12 +46,14 @@ compilation")
     elseif(${OS} MATCHES "MINGW64")
     message(STATUS "\n\nMINGW64 DECTECTED (This is still experimental)")
     message(STATUS "Make sure the library names are consistent")  # !
+    set(USE_MINGW64 1)
     set(libaslname "libcoinasl.dll.a")
     set(libhslname "libcoinhsl.dll.a")
     set(libmetisname "libmetis.dll.a")
     set(libblasname "libblas.dll.a")
     set(liblapackname "liblapack.dll.a")
     set(LDL "")
+    set(QUADMATH "quadmath")
     elseif(${OS} MATCHES "Darwin")
    message(STATUS "\n\nYou are trying to compile k_aug in Mac OS X")
    message(STATUS "\n\nMake sure the libgfortran.dylib is available in a
@@ -76,7 +78,7 @@ set(k_aug_version_minor 0)
 
 set(USE_PARDISO 0)
 set(USE_MC30 0)
-set(PRINT_VERBOSE 1)
+set(PRINT_VERBOSE 0)
  
 
 configure_file("${PROJECT_SOURCE_DIR}/src/common/config_kaug.h.in"
@@ -88,25 +90,23 @@ include_directories(${PROJECT_BINARY_DIR})
 
 # coinor stuff
 # PLEASE MAKE SURE THIS ARE IN THE CORRECT DIRECTORY
-include_directories(/home/rparker1/Solvers/CoinIpopt/build/include/coin/ThirdParty)
-find_library(COINASL NAMES asl ${libaslname} HINTS /home/rparker1/Solvers/CoinIpopt/build/lib /usr/local/lib REQUIRED)
-find_library(COINHSL ${libhslname} HINTS /home/rparker1/Solvers/CoinIpopt/build/lib /usr/local/lib REQUIRED)
-find_library(COINMETIS NAMES metis ${libmetisname} HINTS /home/rparker1/Solvers/CoinIpopt/build/lib /usr/local/lib
-/usr/local/opt/metis/lib/ REQUIRED)
+include_directories(/usr/local/include/coin-or/asl )  #: Add location of asl.h getstub.h
+find_library(COINASL NAMES asl ${libaslname} HINTS /usr/local/lib REQUIRED)  #: Add hints
+find_library(COINHSL NAMES ${libhslname} HINTS /usr/local/lib REQUIRED)  #: Add hints
+find_library(COINMETIS NAMES metis ${libmetisname} HINTS /usr/local/lib REQUIRED)  #: Add hints
+
 # openblas/blas stuff
-find_library(BLAS NAMES blas ${libblasname} HINTS /home/rparker1/Solvers/CoinIpopt/build/lib /usr/lib /usr/local/lib REQUIRED)
-find_library(LAPACK NAMES lapack ${liblapackname} HINTS /home/rparker1/Solvers/CoinIpopt/build/lib /usr/lib /usr/local/lib REQUIRED)
-find_library(GFORTRAN NAMES gfortran HINTS /usr/lib/x86_64-linux-gnu /usr/lib/gcc/x86_64-linux-gnu/7 /usr/local/opt/gcc/lib/gcc/10 REQUIRED)  #: ATTENTION MAC OS X USERS!
- 
+find_library(BLAS NAMES blas ${libblasname} HINTS /usr/lib /usr/local/lib REQUIRED)  #: Add hints
+find_library(LAPACK NAMES lapack ${liblapackname} HINTS /usr/lib /usr/local/lib REQUIRED)  #: Add hints
+#: libgfortran
+find_library(GFORTRAN NAMES gfortran HINTS /usr/local/opt/gcc/lib/gcc/10 REQUIRED)  #: Sometimes on macOS /usr/local/opt/gcc/lib/gcc/10
+#: Sometimes on linux /usr/lib/gcc/x86_64-linux-gnu/X otherwise /usr/lib/gcc/arch-os/VERSION
 
- 
+message(STATUS "\n\n'")
 
- 
-
-get_property(dirs DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY
-INCLUDE_DIRECTORIES)
-message(STATUS "\n\n\nThe include directories must have getstub.h, arith.h,
-and asl.h!!!\n\n\n")
+get_property(dirs DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)
+message(STATUS
+        "\n\n\nThe include directories must have getstub.h, arith.h, and asl.h!!!\n\n\n")
 foreach(dir ${dirs})
     message(STATUS "Including directory='${dir}'")
 endforeach()
@@ -146,22 +146,18 @@ add_executable(k_aug ${SRC_FILES})
 add_executable(dot_sens src/k_aug/dot_driver/dot_driver.c)
 if (USE_MC30)
     #target_link_libraries(k_aug amplsolver m dl gfortran dmumps mumps_common
-#pthread esmumps scotch scotcherr metis pord mpiseq mc30 gfortran openblas
-#ma57)
+    #pthread esmumps scotch scotcherr metis pord mpiseq mc30 gfortran openblas
+    #ma57)
     target_link_libraries(k_aug mc30 ${COINASL} ${COINHSL} ${COINMETIS}
-${LAPACK} ${BLAS} ${GFORTRAN} m ${LDL})
+${LAPACK} ${BLAS} ${GFORTRAN} ${QUADMATH} m ${LDL})
     message("LINKING MC30 ${USE_MC30}")
 else(USE_MC30)
-message(${LAPACK})
-message(${GFORTRAN})
 target_link_libraries(k_aug ${COINASL} ${COINHSL} ${COINMETIS}  ${LAPACK}
-${BLAS} ${GFORTRAN} m ${LDL})
+${BLAS} ${GFORTRAN} ${QUADMATH} m ${LDL})
 endif(USE_MC30)
  
 
- 
-
-target_link_libraries(dot_sens ${COINASL} ${BLAS} ${GFORTRAN} m ${LDL})
+target_link_libraries(dot_sens ${COINASL} ${BLAS} ${GFORTRAN} ${QUADMATH} m ${LDL})
  
 
  

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,7 @@ set(SRC_FILES ${PROJECT_SOURCE_DIR}/src/k_aug/main_.c
         ${PROJECT_SOURCE_DIR}/src/k_aug/csr_driver.c
         ${PROJECT_SOURCE_DIR}/src/k_aug/dot_driver.c
         ${PROJECT_SOURCE_DIR}/src/k_aug/find_inequalities.c
+        ${PROJECT_SOURCE_DIR}/src/k_aug/get_grad_f.c
         ${PROJECT_SOURCE_DIR}/src/k_aug/get_jac_asl_aug.c
         ${PROJECT_SOURCE_DIR}/src/k_aug/get_hess_asl_aug.c
         ${PROJECT_SOURCE_DIR}/src/k_aug/inertia_strategy.c

--- a/src/k_aug/main_.c
+++ b/src/k_aug/main_.c
@@ -151,7 +151,7 @@ static keyword keywds[] = {
 };
 
 
-static char banner[] = {"K_AUG 0.1.0 \n\n"};
+static char banner[] = {"K_AUG 0.1.0\n\n"};
 static char _k_[] = {"k_aug"};
 static char _k_o_[] = {"k_aug_options"};
 static Option_Info Oinfo;

--- a/src/k_aug/main_.c
+++ b/src/k_aug/main_.c
@@ -151,7 +151,7 @@ static keyword keywds[] = {
 };
 
 
-static char banner[] = {"[K_AUG] written by D.T. @2018\n\n"};
+static char banner[] = {"K_AUG 0.1.0 \n\n"};
 static char _k_[] = {"k_aug"};
 static char _k_o_[] = {"k_aug_options"};
 static Option_Info Oinfo;


### PR DESCRIPTION
A recent change to Pyomo, mentioned here https://github.com/Pyomo/pyomo/pull/1613#discussion_r619500008, requires unrecognized asl solvers to report their version number when invoked with `-v`. The banner that k_aug displays is not recognized as a version number, so `SolverFactory('k_aug').available()` returns false.
This PR updates `k_aug -v` to print
```console
K_AUG 0.1.0 (Linux x86_64), ASL(20180528)
```
For reference, Ipopt prints
```console
Ipopt 3.12 (Linux x86_64), ASL(20180528)
```

I did not do anything sophisticated, just altered the "banner" variable to display an arbitrary version number that we can use as a basis for future development. There may be a way to keep the "banner" variable add a version number separately, but I did not feel like digging into the asl interface to figure that out.
