### PR TITLE
Make k_aug compile "non-verbose" by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ set(k_aug_version_minor 0)
 
 set(USE_PARDISO 0)
 set(USE_MC30 0)
-set(PRINT_VERBOSE 0)
+set(PRINT_VERBOSE 1)
  
 
 configure_file("${PROJECT_SOURCE_DIR}/src/common/config_kaug.h.in"


### PR DESCRIPTION
K_aug in "verbose mode" is hard to embed in other applications as the first thing it does, even upon inspecting the version with `k_aug -v`, is to create a `kaug_debug` directory. I would like to be able to call `k_aug -v` without creating this directory. There may be a better way to do this, but the easiest is to simply not use verbose mode. As I would like this to be the case in the version of k_aug distributed by IDAES, verbose mode should not be the default.